### PR TITLE
Changes to item properties

### DIFF
--- a/examples/item_no_version.json
+++ b/examples/item_no_version.json
@@ -31,16 +31,12 @@
     "cmip6:source": "BCC-CSM 2 MR (2017):   aerosol: none  atmos: BCC_AGCM3_MR (T106; 320 x 160 longitude/latitude; 46 levels; top level 1.46 hPa)  atmosChem: none  land: BCC_AVIM2  landIce: none  ocean: MOM4 (1/3 deg 10S-10N, 1/3-1 deg 10-30 N/S, and 1 deg in high latitudes; 360 x 232 longitude/latitude; 40 levels; top grid cell 0-10 m)  ocnBgchem: none  seaIce: SIS2",
     "cmip6:source_id": "BCC-CSM2-MR",
     "cmip6:source_type": [
-      "AOGCM",
-      "AER",
-      "CHEM",
-      "BGC"
+      "AOGCM"
     ],
     "cmip6:sub_experiment": "none",
     "cmip6:sub_experiment_id": "none",
     "cmip6:table_id": "day",
-    "cmip6:variant_label": "r1i1p1f1",
-    "cmip6:version": "v20190429"
+    "cmip6:variant_label": "r1i1p1f1"
   },
   "geometry": {
     "type": "Polygon",

--- a/json-schema/schema.json
+++ b/json-schema/schema.json
@@ -95,8 +95,7 @@
           "allOf": [
             {
               "$comment": "Require fields here for Collections (top-level).",
-              "required": [
-              ]
+              "required": []
             },
             {
               "$ref": "#/definitions/fields"
@@ -237,17 +236,18 @@
         "cmip6:physics_index": {"type": "number"},
         "cmip6:product": {"type": "string"},
         "cmip6:realization_index": {"type": "number"},
-        "cmip6:realm": {"type": "string"},
+        "cmip6:realm": {"type": "array", "items": {"type": "string"}},
         "cmip6:source": {"type": "string"},
         "cmip6:source_id": {"type": "string"},
-        "cmip6:source_type": {"type": "string"},
+        "cmip6:source_type": {"type": "array", "items": {"type": "string"}},
         "cmip6:sub_experiment": {"type": "string"},
         "cmip6:sub_experiment_id": {"type": "string"},
         "cmip6:table_id": {"type": "string"},
         "cmip6:variant_label": {"type": "string"},
         "cmip6:creation_date": {"type": "string"},
         "cmip6:tracking_id": {"type": "string"},
-        "cmip6:variable_id": {"type": "string"}
+        "cmip6:variable_id": {"type": "string"},
+        "cmip6:version": {"type": "string"}
       },
       "patternProperties": {
         "^(?!cmip6:)": {}


### PR DESCRIPTION
### Proposing a few changes to the schema:

1. Changing ``cmip6:realm`` and ``cmip6:source_type`` to be types ``arrays`` rather than ``strings``. Some CMIP6 variables can belong to more than one realm and more than one source type.

2. Adding an optional ``cmip6:version`` property. Although this is not a required global attribute, it does form an important part of the DRS and "used for example, to construct file names, directory structures, the further_info_url, and in facets of some search tools" ([Data Reference Syntax (DRS) components](https://docs.google.com/document/d/1h0r8RZr_f3-8egBMMh7aqLwy3snpD6_MrDz1q8n5XUk/edit)). Since this property helps distinguish between more than one versions of the same file on the ESGF nodes, it can be used for the same purpose on STAC catalogs. Though I think this ought to be a required field in the extension, since this is not a required global metadata field in ESGF data files, I am making this optional.